### PR TITLE
In WKIconDatabaseTryGetCGImageForURL check iconDatabaseRef for null

### DIFF
--- a/Source/WebKit2/UIProcess/API/C/cg/WKIconDatabaseCG.cpp
+++ b/Source/WebKit2/UIProcess/API/C/cg/WKIconDatabaseCG.cpp
@@ -36,13 +36,13 @@ using namespace WebCore;
 
 CGImageRef WKIconDatabaseTryGetCGImageForURL(WKIconDatabaseRef iconDatabaseRef, WKURLRef urlRef, WKSize size)
 {
-    Image* image = toImpl(iconDatabaseRef)->imageForPageURL(toWTFString(urlRef));
+    Image* image = iconDatabaseRef ? toImpl(iconDatabaseRef)->imageForPageURL(toWTFString(urlRef)) : 0;
     return image ? image->getFirstCGImageRefOfSize(IntSize(static_cast<int>(size.width), static_cast<int>(size.height))) : 0;
 }
 
 CFArrayRef WKIconDatabaseTryCopyCGImageArrayForURL(WKIconDatabaseRef iconDatabaseRef, WKURLRef urlRef)
 {
-    Image* image = toImpl(iconDatabaseRef)->imageForPageURL(toWTFString(urlRef));
+    Image* image = iconDatabaseRef ? toImpl(iconDatabaseRef)->imageForPageURL(toWTFString(urlRef)) : 0;
     return image ? image->getCGImageArray().leakRef() : 0;
 }
 


### PR DESCRIPTION
WKIconDatabaseTryGetCGImageForURL causes null pointer dereference crashes in Safari. Though not fixing the underlying issue, since the WKIconDatabaseTry\* functions are best-effort and are expected to return null, it should be safe to return a null image ref if the input database is unexpectedly null.
